### PR TITLE
Functions added for accessing the hitcount statistics

### DIFF
--- a/FortigateManager/FortigateManager.psd1
+++ b/FortigateManager/FortigateManager.psd1
@@ -3,7 +3,7 @@
 	RootModule        = 'FortigateManager.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '1.2.2'
+	ModuleVersion     = '1.3.0'
 
 	# ID used to uniquely identify this module
 	GUID              = '6c74c0d7-80cf-4bef-8fe1-19ac4a89c438'
@@ -53,11 +53,14 @@
 		'Get-FMAddressGroup'
 		'Get-FMAdomLockStatus'
 		'Get-FMDeviceInfo'
+		'Get-FMFirewallHitCount'
 		'Get-FMFirewallPolicy'
 		'Get-FMFirewallService'
 		'Get-FMLastConnection'
 		'Get-FMPolicyPackage'
 		'Get-FMSystemStatus'
+		'Get-FMTaskResult'
+		'Get-FMTaskStatus'
 		'Invoke-FMAPI'
 		'Lock-FMAdom'
 		'Move-FMFirewallPolicy'

--- a/FortigateManager/en-us/strings.psd1
+++ b/FortigateManager/en-us/strings.psd1
@@ -13,8 +13,11 @@
 	'APICall.Get-FMDeviceInfo'              = 'Query device Info of ADOM {0}'
 	'APICall.Get-FMFirewallPolicy'          = 'Query Firewall-Policy from ADOM {0}/Policy Package {1}'
 	'APICall.Get-FMFirewallService'         = 'Query Firewall-Services from ADOM {0}'
+	'APICall.Get-FMFirewallHitCount'        = 'Query Hitcount for ADOM {0} & Package {1}'
 	'APICall.Get-FMPolicyPackage'           = 'Query Policy Packages'
 	'APICall.Get-FMSystemStatus'            = 'Query Systemstatus'
+	'APICall.Get-FMTaskResult'              = 'Query results of task {0}'
+	'APICall.Get-FMTaskStatus'              = 'Query Status of task {0}'
 	'APICall.Lock-FMAdom'                   = 'Locking ADOM {0}'
 	'APICall.Move-FMFirewallPolicy'         = "Moving Policy {0} {1} {2}, ADOM {3}/Policy Package {4}"
 	'APICall.Publish-FMAdomChange'          = 'Saving changes'

--- a/FortigateManager/functions/Get-FMFirewallHitCount.ps1
+++ b/FortigateManager/functions/Get-FMFirewallHitCount.ps1
@@ -1,0 +1,59 @@
+﻿function Get-FMFirewallHitCount {
+    <#
+    .SYNOPSIS
+    Queries hitcounts for a firewall policy.
+
+    .DESCRIPTION
+    Queries hitcounts for a firewall policy.
+
+    .PARAMETER Connection
+    The API connection object.
+
+    .PARAMETER ADOM
+    The (non-default) ADOM for the requests.
+
+    .PARAMETER EnableException
+    If set to True, errors will throw an exception
+
+    .PARAMETER Package
+    The name of the policy package
+
+    .EXAMPLE
+    $hitCountData=Get-FMFirewallHitCount -Package $packageName
+    Write-Host "`$hitCountData.count=$($hitCountData."firewall policy".count)"
+
+    Gets the hitcounts for the firewall policy
+    .NOTES
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $false)]
+        $Connection = (Get-FMLastConnection),
+        [string]$ADOM,
+        [bool]$EnableException = $true,
+        [parameter(mandatory = $true, ParameterSetName = "default")]
+        [string]$Package
+    )
+    $explicitADOM = Resolve-FMAdom -Connection $Connection -Adom $ADOM -EnableException $EnableException
+    $apiCallParameter = @{
+        EnableException     = $EnableException
+        Connection          = $Connection
+        LoggingAction       = "Get-FMFirewallHitCount"
+        LoggingActionValues = @($explicitADOM, $Package)
+        method              = "exec"
+        Parameter           = @{
+            data=@{
+                adom = "$explicitADOM"
+                pkg="$Package"
+            }
+        }
+        Path                = "/sys/hitcount"
+    }
+    $initTaskResult = Invoke-FMAPI @apiCallParameter
+    $taskID = $initTaskResult.result[0].taskid
+    Write-PSFMessage "taskID=$taskID"
+    $taskStatus=Get-FMTaskStatus -Id $taskID -Wait -Verbose
+    Write-PSFMessage "Status of Task $($taskID): $($taskStatus|ConvertTo-Json -Depth 3)"
+    $result=Get-FMTaskResult -Id $taskID -verbose
+    return $result
+}

--- a/FortigateManager/functions/Get-FMTaskResult.ps1
+++ b/FortigateManager/functions/Get-FMTaskResult.ps1
@@ -1,0 +1,52 @@
+﻿function Get-FMTaskResult {
+    <#
+    .SYNOPSIS
+    Queries the results from a prior executed task.
+
+    .DESCRIPTION
+    Queries the results from a prior executed task.
+
+    .PARAMETER Connection
+    The API connection object.
+
+    .PARAMETER Id
+    The Task-ID
+
+    .PARAMETER Wait
+    If set then the task status will be queried until finished/failed.
+
+    .PARAMETER EnableException
+    If set to True, errors will throw an exception
+
+    .EXAMPLE
+    An example
+
+    may be provided later
+
+    .NOTES
+
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $false)]
+        $Connection = (Get-FMLastConnection),
+        [parameter(mandatory = $true)]
+        [string]$Id,
+        [bool]$EnableException = $true
+    )
+    $apiCallParameter = @{
+        EnableException     = $EnableException
+        Connection          = $Connection
+        LoggingAction       = "Get-FMTaskResult"
+        LoggingActionValues = @($Id)
+        method              = "exec"
+        Parameter           = @{
+            data=@{
+                taskid = $Id
+            }
+        }
+        Path                = "/sys/task/result"
+    }
+    $result = Invoke-FMAPI @apiCallParameter
+    return $result.result[0].data
+}

--- a/FortigateManager/functions/Get-FMTaskStatus.ps1
+++ b/FortigateManager/functions/Get-FMTaskStatus.ps1
@@ -1,0 +1,70 @@
+﻿function Get-FMTaskStatus {
+    <#
+    .SYNOPSIS
+    Queries the current state of a system task.
+
+    .DESCRIPTION
+    Queries the current state of a system task.
+
+    .PARAMETER Connection
+    The API connection object.
+
+    .PARAMETER Id
+    The Task-ID
+
+    .PARAMETER Wait
+    If set then the task status will be queried until finished/failed.
+
+    .PARAMETER EnableException
+    If set to True, errors will throw an exception
+
+    .EXAMPLE
+    An example
+
+    may be provided later
+
+    .NOTES
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $false)]
+        $Connection = (Get-FMLastConnection),
+        [parameter(mandatory = $true)]
+        [string]$Id,
+        [switch]$Wait,
+        [bool]$EnableException = $true
+    )
+    $apiCallParameter = @{
+        EnableException     = $EnableException
+        Connection          = $Connection
+        LoggingAction       = "Get-FMTaskStatus"
+        LoggingActionValues = @($Id)
+        method              = "get"
+        Path                = "/task/task/$Id"
+    }
+
+    do {
+        $repeat=$false
+        # if($wait){$repeat=$true}
+        $result = Invoke-FMAPI @apiCallParameter
+        if($wait){
+            if (($result.result.data.num_done + $result.result.data.num_err) -eq 0) {
+                # Still running
+                $repeat=$true
+            }
+            elseif (($result.result.data.num_err) -gt 0) {
+                Write-PSFMessage "Task-Error: $($result.result.data |ConvertTo-Json)"
+                if($EnableException){
+                    throw "Task Error"
+                }
+                return $result.result
+            }
+        }
+        if ($repeat){
+            Write-PSFMessage "Sleeping before repeating"
+            Start-Sleep -Seconds 2
+        }
+    } while ($repeat    )
+    Write-PSFMessage "Result-Status: $($result.result.status)"
+    return $result.result.data
+}

--- a/FortigateManager/internal/functions/CodeCreators/Convert-FMApiGet2FunctionStub.ps1
+++ b/FortigateManager/internal/functions/CodeCreators/Convert-FMApiGet2FunctionStub.ps1
@@ -1,93 +1,186 @@
-﻿function Convert-FMApiGet2FunctionStub {
-    <#
-    .SYNOPSIS
-    Helper function for creating Powershell code out of HashTable Definitions in JSON.
+﻿# function Convert-FMApiGet2FunctionStub {
+#     <#
+#     .SYNOPSIS
+#     Helper function for creating Powershell code out of HashTable Definitions in JSON.
 
-    .DESCRIPTION
-    Helper function for creating Powershell code out of HashTable Definitions in JSON.
+#     .DESCRIPTION
+#     Helper function for creating Powershell code out of HashTable Definitions in JSON.
 
-    .PARAMETER objectName
-    The new Object Name for the function Name
+#     .PARAMETER objectName
+#     The new Object Name for the function Name
 
-    .EXAMPLE
-    InModuleScope fortigatemanager {Convert-FMApi2HashTable}
+#     .EXAMPLE
+#     InModuleScope fortigatemanager {Convert-FMApi2HashTable}
 
-    Takes the JSON Code from the clipboard and replaces it with an auto generated Powershell function.
+#     Takes the JSON Code from the clipboard and replaces it with an auto generated Powershell function.
 
-    .NOTES
-    General notes
-    #>
-    [CmdletBinding()]
-    param (
-        [parameter(Mandatory = $false)]
-        $Connection = (Get-FMLastConnection),
-        [Parameter()]
-        [String]
-        $objectName = "",
-        [string]$Url
-    )
-    $copy2ClipBoardData = @()
-    $apiCallParameter = @{
-        EnableException     = $true
-        Connection          = $Connection
-        LoggingAction       = "Query-Syntax"
-        LoggingActionValues = $Url
-        method              = "get"
-        Parameter           = @{
-            'option' = "syntax"
-        }
-        Path                = $Url
-    }
-    $newLineCommaDelim = @"
-,
+#     .NOTES
+#     General notes
+#     #>
+#     [CmdletBinding()]
+#     param (
+#         [parameter(Mandatory = $false)]
+#         $Connection = (Get-FMLastConnection),
+#         [Parameter()]
+#         [String]
+#         $objectName = "",
+#         [string]$Url
+#     )
+#     $copy2ClipBoardData = @()
+#     $apiCallParameter = @{
+#         EnableException     = $true
+#         Connection          = $Connection
+#         LoggingAction       = "Query-Syntax"
+#         LoggingActionValues = $Url
+#         method              = "get"
+#         Parameter           = @{
+#             'option' = "syntax"
+#         }
+#         Path                = $Url
+#     }
+#     $newLineCommaDelim = @"
+# ,
 
-"@
-    $newLineDelim = @"
+# "@
+#     $newLineDelim = @"
 
 
-"@
+# "@
 
-    $result = Invoke-FMAPI @apiCallParameter
-    $global:syntax = $result.result[0]
-    try {
-        $objectName = $syntax.data.PSObject.Properties.name
-        $objectNameCC = ConvertTo-CamelCase $objectName
-        $copy2ClipBoardData = @()
-        $copy2ClipBoardData += @"
-        function New-FMObj$objectNameCC {
-                <#
-    .SYNOPSIS
-    Creates a new $objectName object with the given attributes.
+#     $result = Invoke-FMAPI @apiCallParameter
+#     $global:syntax = $result.result[0]
+#     try {
+#         $objectName = $syntax.data.PSObject.Properties.name
+#         $objectNameCC = ConvertTo-CamelCase $objectName
+#         $copy2ClipBoardData = @()
+#         $copy2ClipBoardData += @"
+#         function New-FMObj$objectNameCC {
+#                 <#
+#     .SYNOPSIS
+#     Creates a new $objectName object with the given attributes.
 
-    .DESCRIPTION
-    Creates a new $objectName object with the given attributes.
-"@
-        $defHelp = @()
-        $defParameter = @()
-        $defHashMap = @()
-        #region Insert Parsed Data
-        $attributes = $syntax.data.$objectName.attr
-        $sortedAttributeNameList = $attributes.PSObject.Properties.name|Sort-Object
-        foreach ($attr in $sortedAttributeNameList) {
-            $parameterName = ConvertTo-CamelCase $attr
-            # $parameterName = [regex]::Replace($sourceKey.Trim('_'), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
-            $defHelp+=("    .PARAMETER $parameterName")
-            if ($attributes.$attr.help){
-                $defHelp+=("    $($attributes.$attr.help)")
-            }
-            $defHelp+=("    This parameter is stored in the API attribute $attr.")
-            if ($attributes.$attr.default){
-                $defHelp+=("    Default Value: $($attributes.$attr.default)")
-            }
-            $defHelp+=$newLineDelim
-            # $parameterType = $sourceHashTable.$sourceKey.gettype()
-            # $parameterValue = $sourceHashTable.$sourceKey
-            Write-PSFMessage "`$parameterName=$parameterName; Type=$parameterType;value=$parameterValue"
-            #     $defParameter+=@"
-            #         [parameter(mandatory = `$false, ParameterSetName = "default")]
-            #         [$parameterType]`$$parameterName
-            # "@
-            # Hashtable Definition ergänzen
+#     .DESCRIPTION
+#     Creates a new $objectName object with the given attributes.
+# "@
+#         $defHelp = @()
+#         $defParameter = @()
+#         $defHashMap = @()
+#         #region Insert Parsed Data
+#         $attributes = $syntax.data.$objectName.attr
+#         $sortedAttributeNameList = $attributes.PSObject.Properties.name|Sort-Object
+#         foreach ($attr in $sortedAttributeNameList) {
+#             $parameterName = ConvertTo-CamelCase $attr
+#             # $parameterName = [regex]::Replace($sourceKey.Trim('_'), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
+#             $defHelp+=("    .PARAMETER $parameterName")
+#             if ($attributes.$attr.help){
+#                 $defHelp+=("    $($attributes.$attr.help)")
+#             }
+#             $defHelp+=("    This parameter is stored in the API attribute $attr.")
+#             if ($attributes.$attr.default){
+#                 $defHelp+=("    Default Value: $($attributes.$attr.default)")
+#             }
+#             $defHelp+=$newLineDelim
+#             # $parameterType = $sourceHashTable.$sourceKey.gettype()
+#             # $parameterValue = $sourceHashTable.$sourceKey
+#             Write-PSFMessage "`$parameterName=$parameterName; Type=$parameterType;value=$parameterValue"
+#             #     $defParameter+=@"
+#             #         [parameter(mandatory = `$false, ParameterSetName = "default")]
+#             #         [$parameterType]`$$parameterName
+#             # "@
+#             # Hashtable Definition ergänzen
+# #             switch ($parameterType) {
+# #                 "long" {
+# #                     $defParameter += @"
+# #         [parameter(mandatory = `$false, ParameterSetName = "default")]
+# #         [$parameterType]`$$parameterName=-1
+# # "@
+# #                 }
+# #                 Default {
+# #                     switch -regex ($parameterValue) {
+# #                         "disable|disable" {
+# #                             $defParameter += @"
+# #             [parameter(mandatory = `$false, ParameterSetName = "default")]
+# #             [ValidateSet("disable", "enable")]
+# #             [$parameterType]`$$parameterName
+# # "@
+# #                         }
+# #                         Default {
+# #                             $defParameter += @"
+# #             [parameter(mandatory = `$false, ParameterSetName = "default")]
+# #             [$parameterType]`$$parameterName
+# # "@
+# #                         }
+# #                     }
+# #                 }
+# #             }
+#             # Hashtable Definition ergänzen
+#             # switch ($parameterType) {
+#             #     "System.Object[]" { $defHashMap += "'$sourceKey'=@(`$$parameterName)" }
+#             #     "string" { $defHashMap += "'$sourceKey'=`"`$$parameterName`"" }
+#             #     "long" { $defHashMap += "'$sourceKey'=`$$parameterName" }
+#             #     Default { Write-PSFMessage -Level Warning "Unknown ParamaterType $parameterType" }
+#             # }
+#         }
+#         #endregion
+#         $defHelp+=@"
+#     .EXAMPLE
+#     Example has to be
+
+#     implemented
+
+#     .NOTES
+#     General notes
+#     #>
+# "@
+#         $defParameter += @"
+#         [ValidateSet("Keep", "RemoveAttribute", "ClearContent")]
+#         [parameter(mandatory = `$false, ValueFromPipeline = `$false, ParameterSetName = "default")]
+#         `$NullHandler = "RemoveAttribute"
+# "@
+#         $copy2ClipBoardData += ($defHelp | Join-String $newLineDelim)
+#         $copy2ClipBoardData += ($defParameter | Join-String $newLineCommaDelim)
+#         $copy2ClipBoardData += ")"
+#         $copy2ClipBoardData += "`$data=@{"
+#         $copy2ClipBoardData += ($defHashMap | Out-String)
+#         $copy2ClipBoardData += "}"
+#         $copy2ClipBoardData += "return `$data | Remove-FMNullValuesFromHashtable -NullHandler `$NullHandler"
+#         $copy2ClipBoardData += "}"
+
+#         return $copy2ClipBoardData  | out-string
+#     }
+#     catch {
+#         Write-PSFMessage -Level Warning "Error, $_"
+#         Write-Host "Error, $_"
+#         throw $_
+#     }
+#     return $syntax #|convertto-json -Depth 10
+#     $json = Get-Clipboard
+
+#     $newLineCommaDelim = @"
+# ,
+
+# "@
+#     try {
+#         $copy2ClipBoardData = @()
+#         $copy2ClipBoardData += @"
+# function New-FMObj$objectName {
+#     [CmdletBinding()]
+#     param (
+# "@
+#         $defParameter = @()
+#         $defHashMap = @()
+#         $sourceHashTable = $json | ConvertFrom-Json -ErrorAction Stop | convertto-psfhashtable
+#         $sourceKeyList = $sourceHashTable.Keys | Sort-Object
+#         foreach ($sourceKey in $sourceKeyList) {
+#             $parameterName = [regex]::Replace($sourceKey.Trim('_'), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
+#             $parameterType = $sourceHashTable.$sourceKey.gettype()
+#             $parameterValue = $sourceHashTable.$sourceKey
+#             Write-PSFMessage "`$parameterName=$parameterName; Type=$parameterType;value=$parameterValue"
+#             #     $defParameter+=@"
+#             #         [parameter(mandatory = `$false, ParameterSetName = "default")]
+#             #         [$parameterType]`$$parameterName
+#             # "@
+#             # Hashtable Definition ergänzen
 #             switch ($parameterType) {
 #                 "long" {
 #                     $defParameter += @"
@@ -113,123 +206,30 @@
 #                     }
 #                 }
 #             }
-            # Hashtable Definition ergänzen
-            # switch ($parameterType) {
-            #     "System.Object[]" { $defHashMap += "'$sourceKey'=@(`$$parameterName)" }
-            #     "string" { $defHashMap += "'$sourceKey'=`"`$$parameterName`"" }
-            #     "long" { $defHashMap += "'$sourceKey'=`$$parameterName" }
-            #     Default { Write-PSFMessage -Level Warning "Unknown ParamaterType $parameterType" }
-            # }
-        }
-        #endregion
-        $defHelp+=@"
-    .EXAMPLE
-    Example has to be
-
-    implemented
-
-    .NOTES
-    General notes
-    #>
-"@
-        $defParameter += @"
-        [ValidateSet("Keep", "RemoveAttribute", "ClearContent")]
-        [parameter(mandatory = `$false, ValueFromPipeline = `$false, ParameterSetName = "default")]
-        `$NullHandler = "RemoveAttribute"
-"@
-        $copy2ClipBoardData += ($defHelp | Join-String $newLineDelim)
-        $copy2ClipBoardData += ($defParameter | Join-String $newLineCommaDelim)
-        $copy2ClipBoardData += ")"
-        $copy2ClipBoardData += "`$data=@{"
-        $copy2ClipBoardData += ($defHashMap | Out-String)
-        $copy2ClipBoardData += "}"
-        $copy2ClipBoardData += "return `$data | Remove-FMNullValuesFromHashtable -NullHandler `$NullHandler"
-        $copy2ClipBoardData += "}"
-
-        return $copy2ClipBoardData  | out-string
-    }
-    catch {
-        Write-PSFMessage -Level Warning "Error, $_"
-        Write-Host "Error, $_"
-        throw $_
-    }
-    return $syntax #|convertto-json -Depth 10
-    $json = Get-Clipboard
-
-    $newLineCommaDelim = @"
-,
-
-"@
-    try {
-        $copy2ClipBoardData = @()
-        $copy2ClipBoardData += @"
-function New-FMObj$objectName {
-    [CmdletBinding()]
-    param (
-"@
-        $defParameter = @()
-        $defHashMap = @()
-        $sourceHashTable = $json | ConvertFrom-Json -ErrorAction Stop | convertto-psfhashtable
-        $sourceKeyList = $sourceHashTable.Keys | Sort-Object
-        foreach ($sourceKey in $sourceKeyList) {
-            $parameterName = [regex]::Replace($sourceKey.Trim('_'), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
-            $parameterType = $sourceHashTable.$sourceKey.gettype()
-            $parameterValue = $sourceHashTable.$sourceKey
-            Write-PSFMessage "`$parameterName=$parameterName; Type=$parameterType;value=$parameterValue"
-            #     $defParameter+=@"
-            #         [parameter(mandatory = `$false, ParameterSetName = "default")]
-            #         [$parameterType]`$$parameterName
-            # "@
-            # Hashtable Definition ergänzen
-            switch ($parameterType) {
-                "long" {
-                    $defParameter += @"
-        [parameter(mandatory = `$false, ParameterSetName = "default")]
-        [$parameterType]`$$parameterName=-1
-"@
-                }
-                Default {
-                    switch -regex ($parameterValue) {
-                        "disable|disable" {
-                            $defParameter += @"
-            [parameter(mandatory = `$false, ParameterSetName = "default")]
-            [ValidateSet("disable", "enable")]
-            [$parameterType]`$$parameterName
-"@
-                        }
-                        Default {
-                            $defParameter += @"
-            [parameter(mandatory = `$false, ParameterSetName = "default")]
-            [$parameterType]`$$parameterName
-"@
-                        }
-                    }
-                }
-            }
-            # Hashtable Definition ergänzen
-            switch ($parameterType) {
-                "System.Object[]" { $defHashMap += "'$sourceKey'=@(`$$parameterName)" }
-                "string" { $defHashMap += "'$sourceKey'=`"`$$parameterName`"" }
-                "long" { $defHashMap += "'$sourceKey'=`$$parameterName" }
-                Default { Write-PSFMessage -Level Warning "Unknown ParamaterType $parameterType" }
-            }
-        }
-        $defParameter += @"
-        [ValidateSet("Keep", "RemoveAttribute", "ClearContent")]
-        [parameter(mandatory = `$false, ValueFromPipeline = `$false, ParameterSetName = "default")]
-        `$NullHandler = "RemoveAttribute"
-"@
-        $copy2ClipBoardData += ($defParameter | Join-String $newLineCommaDelim)
-        $copy2ClipBoardData += ")"
-        $copy2ClipBoardData += "`$data=@{"
-        $copy2ClipBoardData += ($defHashMap | Out-String)
-        $copy2ClipBoardData += "}"
-        $copy2ClipBoardData += "return `$data | Remove-FMNullValuesFromHashtable -NullHandler `$NullHandler"
-        $copy2ClipBoardData += "}"
-        Write-PSFMessage -Level Host ($copy2ClipBoardData  | out-string)
-        $copy2ClipBoardData  | out-string | Set-Clipboard
-    }
-    catch {
-        Write-PSFMessage -Level Warning "Clipboard did not contain a JSON String, $_"
-    }
-}
+#             # Hashtable Definition ergänzen
+#             switch ($parameterType) {
+#                 "System.Object[]" { $defHashMap += "'$sourceKey'=@(`$$parameterName)" }
+#                 "string" { $defHashMap += "'$sourceKey'=`"`$$parameterName`"" }
+#                 "long" { $defHashMap += "'$sourceKey'=`$$parameterName" }
+#                 Default { Write-PSFMessage -Level Warning "Unknown ParamaterType $parameterType" }
+#             }
+#         }
+#         $defParameter += @"
+#         [ValidateSet("Keep", "RemoveAttribute", "ClearContent")]
+#         [parameter(mandatory = `$false, ValueFromPipeline = `$false, ParameterSetName = "default")]
+#         `$NullHandler = "RemoveAttribute"
+# "@
+#         $copy2ClipBoardData += ($defParameter | Join-String $newLineCommaDelim)
+#         $copy2ClipBoardData += ")"
+#         $copy2ClipBoardData += "`$data=@{"
+#         $copy2ClipBoardData += ($defHashMap | Out-String)
+#         $copy2ClipBoardData += "}"
+#         $copy2ClipBoardData += "return `$data | Remove-FMNullValuesFromHashtable -NullHandler `$NullHandler"
+#         $copy2ClipBoardData += "}"
+#         Write-PSFMessage -Level Host ($copy2ClipBoardData  | out-string)
+#         $copy2ClipBoardData  | out-string | Set-Clipboard
+#     }
+#     catch {
+#         Write-PSFMessage -Level Warning "Clipboard did not contain a JSON String, $_"
+#     }
+# }

--- a/FortigateManager/internal/functions/CodeCreators/Convert-FMApiGet2FunctionStub.ps1
+++ b/FortigateManager/internal/functions/CodeCreators/Convert-FMApiGet2FunctionStub.ps1
@@ -1,0 +1,235 @@
+﻿function Convert-FMApiGet2FunctionStub {
+    <#
+    .SYNOPSIS
+    Helper function for creating Powershell code out of HashTable Definitions in JSON.
+
+    .DESCRIPTION
+    Helper function for creating Powershell code out of HashTable Definitions in JSON.
+
+    .PARAMETER objectName
+    The new Object Name for the function Name
+
+    .EXAMPLE
+    InModuleScope fortigatemanager {Convert-FMApi2HashTable}
+
+    Takes the JSON Code from the clipboard and replaces it with an auto generated Powershell function.
+
+    .NOTES
+    General notes
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $false)]
+        $Connection = (Get-FMLastConnection),
+        [Parameter()]
+        [String]
+        $objectName = "",
+        [string]$Url
+    )
+    $copy2ClipBoardData = @()
+    $apiCallParameter = @{
+        EnableException     = $true
+        Connection          = $Connection
+        LoggingAction       = "Query-Syntax"
+        LoggingActionValues = $Url
+        method              = "get"
+        Parameter           = @{
+            'option' = "syntax"
+        }
+        Path                = $Url
+    }
+    $newLineCommaDelim = @"
+,
+
+"@
+    $newLineDelim = @"
+
+
+"@
+
+    $result = Invoke-FMAPI @apiCallParameter
+    $global:syntax = $result.result[0]
+    try {
+        $objectName = $syntax.data.PSObject.Properties.name
+        $objectNameCC = ConvertTo-CamelCase $objectName
+        $copy2ClipBoardData = @()
+        $copy2ClipBoardData += @"
+        function New-FMObj$objectNameCC {
+                <#
+    .SYNOPSIS
+    Creates a new $objectName object with the given attributes.
+
+    .DESCRIPTION
+    Creates a new $objectName object with the given attributes.
+"@
+        $defHelp = @()
+        $defParameter = @()
+        $defHashMap = @()
+        #region Insert Parsed Data
+        $attributes = $syntax.data.$objectName.attr
+        $sortedAttributeNameList = $attributes.PSObject.Properties.name|Sort-Object
+        foreach ($attr in $sortedAttributeNameList) {
+            $parameterName = ConvertTo-CamelCase $attr
+            # $parameterName = [regex]::Replace($sourceKey.Trim('_'), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
+            $defHelp+=("    .PARAMETER $parameterName")
+            if ($attributes.$attr.help){
+                $defHelp+=("    $($attributes.$attr.help)")
+            }
+            $defHelp+=("    This parameter is stored in the API attribute $attr.")
+            if ($attributes.$attr.default){
+                $defHelp+=("    Default Value: $($attributes.$attr.default)")
+            }
+            $defHelp+=$newLineDelim
+            # $parameterType = $sourceHashTable.$sourceKey.gettype()
+            # $parameterValue = $sourceHashTable.$sourceKey
+            Write-PSFMessage "`$parameterName=$parameterName; Type=$parameterType;value=$parameterValue"
+            #     $defParameter+=@"
+            #         [parameter(mandatory = `$false, ParameterSetName = "default")]
+            #         [$parameterType]`$$parameterName
+            # "@
+            # Hashtable Definition ergänzen
+#             switch ($parameterType) {
+#                 "long" {
+#                     $defParameter += @"
+#         [parameter(mandatory = `$false, ParameterSetName = "default")]
+#         [$parameterType]`$$parameterName=-1
+# "@
+#                 }
+#                 Default {
+#                     switch -regex ($parameterValue) {
+#                         "disable|disable" {
+#                             $defParameter += @"
+#             [parameter(mandatory = `$false, ParameterSetName = "default")]
+#             [ValidateSet("disable", "enable")]
+#             [$parameterType]`$$parameterName
+# "@
+#                         }
+#                         Default {
+#                             $defParameter += @"
+#             [parameter(mandatory = `$false, ParameterSetName = "default")]
+#             [$parameterType]`$$parameterName
+# "@
+#                         }
+#                     }
+#                 }
+#             }
+            # Hashtable Definition ergänzen
+            # switch ($parameterType) {
+            #     "System.Object[]" { $defHashMap += "'$sourceKey'=@(`$$parameterName)" }
+            #     "string" { $defHashMap += "'$sourceKey'=`"`$$parameterName`"" }
+            #     "long" { $defHashMap += "'$sourceKey'=`$$parameterName" }
+            #     Default { Write-PSFMessage -Level Warning "Unknown ParamaterType $parameterType" }
+            # }
+        }
+        #endregion
+        $defHelp+=@"
+    .EXAMPLE
+    Example has to be
+
+    implemented
+
+    .NOTES
+    General notes
+    #>
+"@
+        $defParameter += @"
+        [ValidateSet("Keep", "RemoveAttribute", "ClearContent")]
+        [parameter(mandatory = `$false, ValueFromPipeline = `$false, ParameterSetName = "default")]
+        `$NullHandler = "RemoveAttribute"
+"@
+        $copy2ClipBoardData += ($defHelp | Join-String $newLineDelim)
+        $copy2ClipBoardData += ($defParameter | Join-String $newLineCommaDelim)
+        $copy2ClipBoardData += ")"
+        $copy2ClipBoardData += "`$data=@{"
+        $copy2ClipBoardData += ($defHashMap | Out-String)
+        $copy2ClipBoardData += "}"
+        $copy2ClipBoardData += "return `$data | Remove-FMNullValuesFromHashtable -NullHandler `$NullHandler"
+        $copy2ClipBoardData += "}"
+
+        return $copy2ClipBoardData  | out-string
+    }
+    catch {
+        Write-PSFMessage -Level Warning "Error, $_"
+        Write-Host "Error, $_"
+        throw $_
+    }
+    return $syntax #|convertto-json -Depth 10
+    $json = Get-Clipboard
+
+    $newLineCommaDelim = @"
+,
+
+"@
+    try {
+        $copy2ClipBoardData = @()
+        $copy2ClipBoardData += @"
+function New-FMObj$objectName {
+    [CmdletBinding()]
+    param (
+"@
+        $defParameter = @()
+        $defHashMap = @()
+        $sourceHashTable = $json | ConvertFrom-Json -ErrorAction Stop | convertto-psfhashtable
+        $sourceKeyList = $sourceHashTable.Keys | Sort-Object
+        foreach ($sourceKey in $sourceKeyList) {
+            $parameterName = [regex]::Replace($sourceKey.Trim('_'), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
+            $parameterType = $sourceHashTable.$sourceKey.gettype()
+            $parameterValue = $sourceHashTable.$sourceKey
+            Write-PSFMessage "`$parameterName=$parameterName; Type=$parameterType;value=$parameterValue"
+            #     $defParameter+=@"
+            #         [parameter(mandatory = `$false, ParameterSetName = "default")]
+            #         [$parameterType]`$$parameterName
+            # "@
+            # Hashtable Definition ergänzen
+            switch ($parameterType) {
+                "long" {
+                    $defParameter += @"
+        [parameter(mandatory = `$false, ParameterSetName = "default")]
+        [$parameterType]`$$parameterName=-1
+"@
+                }
+                Default {
+                    switch -regex ($parameterValue) {
+                        "disable|disable" {
+                            $defParameter += @"
+            [parameter(mandatory = `$false, ParameterSetName = "default")]
+            [ValidateSet("disable", "enable")]
+            [$parameterType]`$$parameterName
+"@
+                        }
+                        Default {
+                            $defParameter += @"
+            [parameter(mandatory = `$false, ParameterSetName = "default")]
+            [$parameterType]`$$parameterName
+"@
+                        }
+                    }
+                }
+            }
+            # Hashtable Definition ergänzen
+            switch ($parameterType) {
+                "System.Object[]" { $defHashMap += "'$sourceKey'=@(`$$parameterName)" }
+                "string" { $defHashMap += "'$sourceKey'=`"`$$parameterName`"" }
+                "long" { $defHashMap += "'$sourceKey'=`$$parameterName" }
+                Default { Write-PSFMessage -Level Warning "Unknown ParamaterType $parameterType" }
+            }
+        }
+        $defParameter += @"
+        [ValidateSet("Keep", "RemoveAttribute", "ClearContent")]
+        [parameter(mandatory = `$false, ValueFromPipeline = `$false, ParameterSetName = "default")]
+        `$NullHandler = "RemoveAttribute"
+"@
+        $copy2ClipBoardData += ($defParameter | Join-String $newLineCommaDelim)
+        $copy2ClipBoardData += ")"
+        $copy2ClipBoardData += "`$data=@{"
+        $copy2ClipBoardData += ($defHashMap | Out-String)
+        $copy2ClipBoardData += "}"
+        $copy2ClipBoardData += "return `$data | Remove-FMNullValuesFromHashtable -NullHandler `$NullHandler"
+        $copy2ClipBoardData += "}"
+        Write-PSFMessage -Level Host ($copy2ClipBoardData  | out-string)
+        $copy2ClipBoardData  | out-string | Set-Clipboard
+    }
+    catch {
+        Write-PSFMessage -Level Warning "Clipboard did not contain a JSON String, $_"
+    }
+}

--- a/FortigateManager/internal/functions/CodeCreators/ConvertTo-CamelCase.ps1
+++ b/FortigateManager/internal/functions/CodeCreators/ConvertTo-CamelCase.ps1
@@ -1,7 +1,26 @@
 ﻿function ConvertTo-CamelCase {
+    <#
+    .SYNOPSIS
+    Converts attribute names into CamelCase parameter names.
+
+    .DESCRIPTION
+    Converts attribute names into CamelCase parameter names.
+
+    .PARAMETER Text
+    The text to be converted.
+
+    .EXAMPLE
+    ConvertTo-CamelCase -Text "first_hit"
+
+    Returns FirstHit
+
+    .NOTES
+    General notes
+    #>
     [CmdletBinding()]
+    [OutputType([string])]
     param (
-        [Parameter(Position = 0)]
+        [Parameter(Mandatory = $true,Position = 0)]
         [string]$Text
     )
     return [regex]::Replace($Text.Trim('_').Trim(' '), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })

--- a/FortigateManager/internal/functions/CodeCreators/ConvertTo-CamelCase.ps1
+++ b/FortigateManager/internal/functions/CodeCreators/ConvertTo-CamelCase.ps1
@@ -1,0 +1,8 @@
+﻿function ConvertTo-CamelCase {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position = 0)]
+        [string]$Text
+    )
+    return [regex]::Replace($Text.Trim('_').Trim(' '), '(?i)(?:^|-| )(\p{L})', { $args[0].Groups[1].Value.ToUpper() })
+}


### PR DESCRIPTION
I need to verify which policy rules are obsolete (no hits).

- The GUI does not allow filtering
- The excel export does exclude the information
- The "/pm/config/adom/$adom/obj/firewall/service/custom" API doesn't return the info either

You need to execute a system task, wait for completion and fetch the results.

Sounds complicated? Not anymore:
```Powershell
$hitCountData=Get-FMFirewallHitCount -Package $packageName
Write-Host "`$hitCountData.count=$($hitCountData."firewall policy".count)"

#Gets the hitcounts for the firewall policy
```