### PR TITLE
Version 2.2.0

### DIFF
--- a/FortigateManager/FortigateManager.psd1
+++ b/FortigateManager/FortigateManager.psd1
@@ -71,6 +71,7 @@
 		'Get-FMTaskStatus'
 		'Invoke-FMAPI'
 		'Lock-FMAdom'
+		'Merge-FMStringHashMap'
 		'Move-FMFirewallPolicy'
 		'New-FMObjAddress'
 		'New-FMObjAddressGroup'

--- a/FortigateManager/FortigateManager.psd1
+++ b/FortigateManager/FortigateManager.psd1
@@ -3,7 +3,7 @@
 	RootModule        = 'FortigateManager.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '2.1.0'
+	ModuleVersion     = '2.2.0'
 
 	# ID used to uniquely identify this module
 	GUID              = '6c74c0d7-80cf-4bef-8fe1-19ac4a89c438'
@@ -49,7 +49,8 @@
 		'Add-FMInterface'
 		'Connect-FM'
 		'Convert-FMIpAddressToMaskLength'
-		'Convert-FMSubnetMask',
+		'Convert-FMSubnetMask'
+		'Convert-FMZone2VLAN'
 		'Disconnect-FM'
 		'Disable-FMFirewallPolicy'
 		'Enable-FMFirewallPolicy'

--- a/FortigateManager/FortigateManager.psd1
+++ b/FortigateManager/FortigateManager.psd1
@@ -61,6 +61,7 @@
 		'Get-FMDeviceInfo'
 		'Get-FMFirewallHitCount'
 		'Get-FMFirewallPolicy'
+		'Get-FMFirewallScope'
 		'Get-FMFirewallService'
 		'Get-FMInterface'
 		'Get-FMLastConnection'

--- a/FortigateManager/changelog.md
+++ b/FortigateManager/changelog.md
@@ -10,3 +10,12 @@
 ## 2.0.3 (2022-10-28)
  - Multiple Addresses can be removed in one request
  - fixed race condition in Invoke-FMApi which occurred while re-using a HashTable for splatting
+## 2.2.0 (2022-11-30)
+ - Added functionality:
+   - ADOM revisions can be created/queried/removed
+   - Merge-FMStringHashMap  
+     Helper funtion to replace placeholders in an url with values from a hashtable.
+   - Convert-FMZone2VLAN  
+     Converts an interface from a firewall policy to the addresses of the physical interfaces/vlan on the relevant devices.
+   - Get-FMFirewallScope  
+   Queries firewall scopes for dynamic mapping etc

--- a/FortigateManager/en-us/strings.psd1
+++ b/FortigateManager/en-us/strings.psd1
@@ -42,6 +42,7 @@
 	'APICall.Update-FMFirewallPolicy'        = '#{0}: Updating {1} policies in ADOM {2}, Policy Package {3}'
 	'APICall.Update-FMFirewallService'       = '#{0}: Updating {1} firewall services in ADOM {2}, additional -Name: {3}'
 	'APICall.Update-FMInterface'             = '#{0}: Updating {1} interfaces in ADOM {2}, additional -Name: {3}'
+	'APICall.Undocumented'                   = '#{0}: Using undocumented API for: {1}'
 	'Connect-FM.Connected'                   = '#{0}: Connection established' #
 	'Connect-FM.NotConnected'                = '#{0}: Connection could not be established'
 }

--- a/FortigateManager/functions/Convert-FMZone2VLAN.ps1
+++ b/FortigateManager/functions/Convert-FMZone2VLAN.ps1
@@ -1,0 +1,41 @@
+﻿function Convert-FMZone2VLAN {
+    <#
+    .SYNOPSIS
+    Short description
+
+    .DESCRIPTION
+    Long description
+
+    .PARAMETER Connection
+    The API connection object.
+
+    .PARAMETER ADOM
+    The (non-default) ADOM for the requests.
+
+    .PARAMETER LoggingLevel
+    On which level should die diagnostic Messages be logged?
+
+    .PARAMETER EnableException
+    If set to True, errors will throw an exception
+
+    .EXAMPLE
+    An example
+
+    .NOTES
+    General notes
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $false)]
+        $Connection = (Get-FMLastConnection),
+        [string]$ADOM,
+        [parameter(Mandatory = $true)]
+        [string[]]$Zone,
+        [ValidateSet('simpleIpList')]
+        $ReturnType,
+        [string]$LoggingLevel,
+        [bool]$EnableException = $true
+    )
+    Write-PSFMessage "Determine VLANs from Zones: $($Zone -join ',')"
+
+}

--- a/FortigateManager/functions/Convert-FMZone2VLAN.ps1
+++ b/FortigateManager/functions/Convert-FMZone2VLAN.ps1
@@ -31,11 +31,101 @@
         [string]$ADOM,
         [parameter(Mandatory = $true)]
         [string[]]$Zone,
-        [ValidateSet('simpleIpList')]
-        $ReturnType,
+        [ValidateSet('simpleIpList', 'ZoneVLANHash')]
+        $ReturnType = 'simpleIpList',
         [string]$LoggingLevel,
         [bool]$EnableException = $true
     )
     Write-PSFMessage "Determine VLANs from Zones: $($Zone -join ',')"
+    Write-PSFMessage "Query all VDOMs and corresponding VLANs"
+    $deviceVdomList = Get-FMDeviceInfo -Connection $connection -Option 'object member' | Select-Object -ExpandProperty "object member" | Where-Object { $_.vdom } | ConvertTo-PSFHashtable -Include name, vdom -Remap @{name = 'device' }
+    foreach ($device in $deviceVdomList) {
+        Write-PSFMessage "Query Device $($device|ConvertTo-Json -Compress)"
+        $apiCallParameter = @{
+            EnableException     = $true
+            LoggingAction       = "Undocumented"
+            Connection          = $Connection
+            LoggingActionValues = "Query all interface VLAN from a specific Device/VDOM"
+            method              = "get"
+            LoggingLevel        = "Verbose"
+            path                = "/pm/config/device/{device}/vdom/{vdom}/system/interface" | Merge-FMStringHashMap -Data $device
+        }
+        $device.vlanHash = @{}
 
+        $currentInterfaces = Invoke-FMAPI @apiCallParameter # | ConvertTo-Json -Depth 6
+        foreach ($interface in $currentInterfaces.result.data) {
+            $name = $interface.name
+            if ($interface.ip[1] -eq '0.0.0.0') {
+                $address = "$($interface.ip[0])/0"
+            }
+            else {
+                $address = Convert-FMSubnetMask -IPMask "$($interface.ip[0])/$($interface.ip[1])"
+            }
+            $device.vlanHash.$name = $address
+            # Write-PSFMessage "Add: $($device.name), $name, $address"
+            # $vlanDataPerVDOM += [PSCustomObject]@{
+            #     deviceName    = $device.name
+            #     interfaceName = $name
+            #     addresses     = $address
+            # }
+        }
+    }
+    switch -regex ($ReturnType) {
+        '.*List' {
+            $returnValue = @()
+        }
+        '.*Hash' {
+            $returnValue = @{}
+        }
+    }
+    Write-PSFMessage "`$returnValue.type=$($returnValue.GetType())"
+    foreach ($curZone in $Zone) {
+        Write-PSFMessage "Checking Zone: $curZone"
+        $queryData = @{zone = $curZone | convertto-fmurlpart }
+        $apiCallParameter = @{
+            EnableException     = $true
+            Connection          = $Connection
+            LoggingAction       = "Undocumented"
+            LoggingActionValues = "Query interfaces from a specific Device/VDOM"
+            method              = "get"
+            LoggingLevel        = 'Verbose'
+        }
+        $singleDeviceVdomURL = "/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone/{zone}"
+        foreach ($queryData in $deviceVdomList) {
+            $queryData.zone = $curZone | convertto-fmurlpart
+            $apiCallParameter.path = $singleDeviceVdomURL | Merge-FMStringHashMap -Data $queryData
+            try {
+                $result = Invoke-FMAPI @apiCallParameter
+                Write-PSFMessage "Found"
+                $interfaceList = $result.result.data.interface
+                # Write-PSFMessage "Query: $($queryData|ConvertTo-Json -compress), Results: $($result|ConvertTo-Json -Depth 4)"
+                Write-PSFMessage "interfaceList for $($queryData|ConvertTo-Json -compress): $($interfaceList -join ',')"
+                foreach ($interface in $interfaceList) {
+                    $vlanIP = $queryData.vlanHash.$interface
+                    switch ($ReturnType) {
+                        'simpleIpList' {
+                            Write-PSFMessage "Adding VLAN Info to simpleIpListList"
+                            $returnValue += $vlanIP
+                        }
+                        'ZoneVLANHash' {
+                            Write-PSFMessage "Adding Interfaces to ZoneVLANHash"
+                            if ( -not $returnValue.ContainsKey($curZone)) {
+                                $returnValue.$curZone = @()
+                            }
+                            $returnValue.$curZone = $vlanIP
+                        }
+                        default {
+                            Write-PSFMessage "`$ReturnType $ReturnType unknown"
+                        }
+                    }
+                }
+
+            }
+            catch {
+                Write-PSFMessage "Zone does not exist for $($queryData|ConvertTo-Json -Compress)"
+            }
+        }
+    }
+    Write-PSFMessage "`$returnValue=$($returnValue|ConvertTo-Json)"
+    return $returnValue
 }

--- a/FortigateManager/functions/Get-FMFirewallScope.ps1
+++ b/FortigateManager/functions/Get-FMFirewallScope.ps1
@@ -1,0 +1,75 @@
+﻿function Get-FMFirewallScope {
+    <#
+    .SYNOPSIS
+    Queries firewall scopes for dynamic mapping etc.
+
+    .DESCRIPTION
+    Queries firewall scopes for dynamic mapping etc.
+    The function returns arrays of matched scopes. Will be most usefull if each VDOM is pinned to a
+    specific device. Then the VDOM name can be used to identify te full scope.
+
+    .PARAMETER Connection
+    The API connection object.
+
+    .PARAMETER ADOM
+    The (non-default) ADOM for the requests.
+
+    .PARAMETER EnableException
+    If set to True, errors will throw an exception
+
+    .PARAMETER VDOM
+    The List of VDOMs which should be matched.
+
+    .PARAMETER DeviceName
+    The List of device names which should be matched.
+
+    .EXAMPLE
+    Get-FMFirewallScope -vdom "bonn"
+
+    Returns @(@{"name"="FW3";"vdom"="bonn"})
+
+    .EXAMPLE
+    Get-FMFirewallScope -deviceName "FW1"
+
+    Returns @(@{"name"="FW1";"vdom"="cologne"},@{"name"="FW1";"vdom"="finance"})
+
+    .NOTES
+    The data is cached within the connection object. If a refresh is needed you have to create a fresh connection.
+
+    Examples are based on the assumption that "Get-FMDeviceInfo" returns (shortened)
+    {"object member":[{"name":"FW1","vdom":"cologne"},{"name":"FW1","vdom":"finance"},{"name":"FW2","vdom":"munich"},{"name":"FW3","vdom":"bonn"},{"name":"FW3","vdom":"finance"},{"name":"All_FortiGate"}]}
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $false)]
+        $Connection = (Get-FMLastConnection),
+        [string]$ADOM,
+        [bool]$EnableException = $true,
+
+        [parameter(mandatory = $false, ParameterSetName = "default")]
+        [String[]]$VDOM,
+        [parameter(mandatory = $false, ParameterSetName = "default")]
+        [String[]]$DeviceName
+    )
+    if ($Connection.forti.containsKey('availableScopes')) {
+        $availableScopes = $Connection.forti.availableScopes
+    }
+    else {
+        Write-PSFMessage -Level Host "Query Device-Info once from manager, store the scopes unter '`$Connection.forti.availableScopes'"
+        $devInfo = Get-FMDeviceInfo -Connection $connection -Option 'object member' -ADOM $ADOM -EnableException $EnableException
+        $availableScopes = $devInfo."object member" | Where-Object { $_.vdom } | Select-Object name, vdom
+        $Connection.forti.availableScopes = $availableScopes
+    }
+
+
+    $queryFilter = "$($null -eq $DeviceName)|$($null -eq $VDOM)"
+    # Write-PSFMessage "Queryfilter=$queryFilter"
+    switch ($queryFilter) {
+        default { $result = $availableScopes }
+        "False|False" { $result = $availableScopes | Where-Object { $_.name -in $DeviceName -and $_.VDOM -in $VDOM } }
+        "False|True" { $result = $availableScopes | Where-Object { $_.name -in $DeviceName } }
+        "True|False" { $result = $availableScopes | Where-Object { $_.VDOM -in $VDOM } }
+    }
+    # Write-PSFMessage "`$result = $($result |ConvertTo-Json)"
+    return $result
+}

--- a/FortigateManager/functions/Merge-FMStringHashMap.ps1
+++ b/FortigateManager/functions/Merge-FMStringHashMap.ps1
@@ -1,0 +1,42 @@
+﻿function Merge-FMStringHashMap {
+    <#
+    .SYNOPSIS
+    Helper funtion to replace placeholders in an url with values from a hashtable.
+
+    .DESCRIPTION
+    Helper funtion to replace placeholders in an url with values from a hashtable.
+
+    .PARAMETER String
+    The string with placeholders
+
+
+
+    .EXAMPLE
+    $dataTable=@{device='FIREWALL';vdom='myVDOM'
+    $url="/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone"
+    Merge-FMStringHashMap -String $url -Data $dataTable
+
+    Returns "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+    .EXAMPLE
+    $dataTable=@{device='FIREWALL';vdom='myVDOM'
+    "/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone" | Merge-FMStringHashMap -String $url -Data $dataTable
+
+    Returns "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+
+    .NOTES
+    General notes
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "default")]
+        [string]$String,
+        [hashtable]$Data,
+        [string]$PlaceHolderStart='{þ',
+        [string]$PlaceHolderEnd='}þ'
+    )
+    $result=$String
+    foreach($key in $data.Keys){
+        $result = $result -replace "[$PlaceHolderStart]+$key[$PlaceHolderEnd]+", $data.$key
+    }
+    $result
+}

--- a/FortigateManager/functions/Merge-FMStringHashMap.ps1
+++ b/FortigateManager/functions/Merge-FMStringHashMap.ps1
@@ -7,21 +7,33 @@
     Helper funtion to replace placeholders in an url with values from a hashtable.
 
     .PARAMETER String
-    The string with placeholders
+    The string with placeholders. Placeholders may be enclosed with {...}  or þ...þ by default.
 
+    .PARAMETER Data
+    The hashtable with the data for the placeholders.
 
+    .PARAMETER PlaceHolderStart
+    If you need to change the placeholder enclosement then this is one of the needed parameters.
+
+    .PARAMETER PlaceHolderEnd
+    If you need to change the placeholder enclosement then this is one of the needed parameters.
 
     .EXAMPLE
-    $dataTable=@{device='FIREWALL';vdom='myVDOM'
+    $dataTable=@{
+            device='FIREWALL';
+            vdom='myVDOM';
+        }
     $url="/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone"
-    Merge-FMStringHashMap -String $url -Data $dataTable
+    Merge-FMStringHashMap -String $url -Data $dataTable |Should -be
+    $url|Merge-FMStringHashMap -Data $dataTable |Should -be "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
 
-    Returns "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+    Returns both "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+
     .EXAMPLE
-    $dataTable=@{device='FIREWALL';vdom='myVDOM'
-    "/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone" | Merge-FMStringHashMap -String $url -Data $dataTable
+    $url="/pm/{keepMe}/device/{device}}/vdom/{vdom}}/system/zone"
+    $url|Merge-FMStringHashMap -Data $dataTable
 
-    Returns "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+    Returns "/pm/{keepMe}/device/FIREWALL/vdom/myVDOM/system/zone"
 
     .NOTES
     General notes
@@ -34,9 +46,15 @@
         [string]$PlaceHolderStart='{þ',
         [string]$PlaceHolderEnd='}þ'
     )
-    $result=$String
-    foreach($key in $data.Keys){
-        $result = $result -replace "[$PlaceHolderStart]+$key[$PlaceHolderEnd]+", $data.$key
+    begin{
     }
-    $result
+    process{
+        $result=$String
+        foreach($key in $data.Keys){
+            $result = $result -replace "[$PlaceHolderStart]+$key[$PlaceHolderEnd]+", $data.$key
+        }
+        $result
+    }
+    end{
+    }
 }

--- a/FortigateManager/tests/functions/Get-FMFirewallScope.Tests.ps1
+++ b/FortigateManager/tests/functions/Get-FMFirewallScope.Tests.ps1
@@ -1,0 +1,93 @@
+Describe  "Tests around Get-FMFirewallScope" {
+    BeforeAll {
+        . $PSScriptRoot\Connect4Testing.ps1
+
+        Mock -ModuleName "FortigateManager" Get-FMDeviceInfo {
+            return @"
+{
+    "object member": [
+    {
+        "name": "FW1",
+        "vdom": "cologne"
+    },
+    {
+        "name": "FW1",
+        "vdom": "finance"
+    },
+    {
+        "name": "FW2",
+        "vdom": "munich"
+    },
+    {
+        "name": "FW3",
+        "vdom": "bonn"
+    },
+    {
+        "name": "FW3",
+        "vdom": "finance"
+    },
+    {
+        "name": "All_FortiGate"
+    }
+    ]
+}
+"@ | ConvertFrom-Json
+        }
+    }
+    AfterAll {
+    }
+    Context "Connected and mocked" {
+        It "Query all scopes" {
+            $scopes = Get-FMFirewallScope -verbose
+            # Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 5
+        }
+        It "Query single VDOM" {
+            $scopes = Get-FMFirewallScope -vdom "bonn"
+            # Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 1
+            $scopes.vdom | Should -Be 'bonn'
+            $scopes.name | Should -Be 'FW3'
+        }
+        It "Query VDOM which happens to exist twice" {
+            $scopes = Get-FMFirewallScope -vdom "finance"
+            Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 2
+            $scopes.vdom | Should -Be @('finance', 'finance')
+            $scopes.name | Should -Contain 'FW3'
+            $scopes.name | Should -Contain 'FW1'
+        }
+        It "Query single Device" {
+            $scopes = Get-FMFirewallScope -deviceName "FW2"
+            # Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 1
+            $scopes.vdom | Should -Be 'munich'
+            $scopes.name | Should -Be 'FW2'
+        }
+        It "Query Device which contains two VDOMs" {
+            $scopes = Get-FMFirewallScope -deviceName "FW1"
+            Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 2
+            $scopes.name | Should -Be @('FW1', 'FW1')
+            $scopes.vdom | Should -Contain 'cologne'
+            $scopes.vdom | Should -Contain 'finance'
+        }
+        It "Query Device which contains two VDOMs, specific VDOM" {
+            $scopes = Get-FMFirewallScope -deviceName "FW1" -vdom 'cologne'
+            Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 1
+            $scopes.name | Should -Be 'FW1'
+            $scopes.vdom | Should -Contain 'cologne'
+            $scopes.vdom | Should -not -Contain 'finance'
+        }
+        It "Query Device which contains two VDOMs, specific VDOM" {
+            $scopes = Get-FMFirewallScope -vdom 'cologne', 'bonn'
+            Write-PSFMessage -Level Host "$($scopes|json)"
+            $scopes | Should -havecount 2
+            $scopes.name | Should -Contain 'FW1'
+            $scopes.name | Should -Contain 'FW3'
+            $scopes.vdom | Should -Contain 'cologne'
+            $scopes.vdom | Should -Contain 'bonn'
+        }
+    }
+}

--- a/FortigateManager/tests/functions/Merge-FMStringHashMap.Tests.ps1
+++ b/FortigateManager/tests/functions/Merge-FMStringHashMap.Tests.ps1
@@ -1,0 +1,23 @@
+Describe  "Tests around Merge-FMStringHashMap" {
+    BeforeAll {
+        $dataTable=@{
+            device='FIREWALL';
+            vdom='myVDOM';
+            notUsefull='thisIs'
+        }
+    }
+    AfterAll {
+    }
+        It "Replace by param" {
+            $url="/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone"
+            Merge-FMStringHashMap -String $url -Data $dataTable |Should -be "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+        }
+        It "Replace by pipe" {
+            $url="/pm/config/device/{{device}}/vdom/{{vdom}}/system/zone"
+            $url|Merge-FMStringHashMap -Data $dataTable |Should -be "/pm/config/device/FIREWALL/vdom/myVDOM/system/zone"
+        }
+        It "Don't touch no-Replaceables" {
+            $url="/pm/{keepMe}/device/{device}}/vdom/{vdom}}/system/zone"
+            $url|Merge-FMStringHashMap -Data $dataTable |Should -be "/pm/{keepMe}/device/FIREWALL/vdom/myVDOM/system/zone"
+        }
+}


### PR DESCRIPTION
Added functionality:
   - ADOM revisions can be created/queried/removed
   - Merge-FMStringHashMap  
     Helper funtion to replace placeholders in an url with values from a hashtable.
   - Convert-FMZone2VLAN  
     Converts an interface from a firewall policy to the addresses of the physical interfaces/vlan on the relevant devices.
   - Get-FMFirewallScope  
   Queries firewall scopes for dynamic mapping etc