### PR TITLE
Added Parameter SkipCheck to Connect-FM

### DIFF
--- a/FortigateManager/FortigateManager.psd1
+++ b/FortigateManager/FortigateManager.psd1
@@ -3,7 +3,7 @@
 	RootModule        = 'FortigateManager.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '2.2.0'
+	ModuleVersion     = '2.2.1'
 
 	# ID used to uniquely identify this module
 	GUID              = '6c74c0d7-80cf-4bef-8fe1-19ac4a89c438'
@@ -27,7 +27,7 @@
 	# this module
 	RequiredModules   = @(
 		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.6.214' }
-		@{ ModuleName = 'ARAH'; ModuleVersion = '1.3.3' }
+		@{ ModuleName = 'ARAH'; ModuleVersion = '1.3.5' }
 	)
 
 	# Assemblies that must be loaded prior to importing this module

--- a/FortigateManager/changelog.md
+++ b/FortigateManager/changelog.md
@@ -19,3 +19,6 @@
      Converts an interface from a firewall policy to the addresses of the physical interfaces/vlan on the relevant devices.
    - Get-FMFirewallScope  
    Queries firewall scopes for dynamic mapping etc
+## 2.2.1 (2023-01-18)
+ - Added Parameter SkipCheck to Connect-FM  
+   Allows e.g. to skip SSL checks while performing the HTTP requests

--- a/FortigateManager/functions/Connect-FM.ps1
+++ b/FortigateManager/functions/Connect-FM.ps1
@@ -15,6 +15,11 @@
 	.PARAMETER ADOM
 	The default ADOM for the requests.
 
+    .PARAMETER SkipCheck
+    Array of checks which should be skipped while using Invoke-WebRequest.
+    Possible Values 'CertificateCheck', 'HttpErrorCheck', 'HeaderValidation'.
+    If neccessary by default for the connection set $connection.SkipCheck
+
 	.PARAMETER EnableException
 	Should Exceptions been thrown?
 
@@ -37,12 +42,15 @@
 		[string]$ADOM,
 		[parameter(mandatory = $true, ParameterSetName = "credential")]
 		[pscredential]$Credential,
+		[ValidateSet('CertificateCheck', 'HttpErrorCheck', 'HeaderValidation')]
+		[String[]]$SkipCheck,
 		[bool]$EnableException = $true
 	)
 	begin {
 	}
 	end {
 		$connection = Get-ARAHConnection -Url $Url -APISubPath ""
+		if ($SkipCheck) { $connection.SkipCheck = $SkipCheck}
 		Add-Member -InputObject $connection -MemberType NoteProperty -Name "forti" -Value @{
 			requestId = 1
 			session   = $null


### PR DESCRIPTION
   Allows e.g. to skip SSL checks while performing the HTTP requests